### PR TITLE
Enable absolute paths in config

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,6 +110,7 @@ memoindex new [ファイル名]
 1. Goインストール
 2. 本リポジトリをクローン
 3. 監視フォルダを設定（例: `config.yaml` 等）
+   - `memo_dir` や `index_path` には絶対パスも指定可能です
 
 ### 2. 起動
 

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"log"
 	"os"
+	"path/filepath"
 
 	"gopkg.in/yaml.v3"
 )
@@ -23,5 +24,17 @@ func LoadConfig(path string) {
 	err = yaml.Unmarshal(data, &AppConfig)
 	if err != nil {
 		log.Fatalf("設定パース失敗: %v", err)
+	}
+
+	// 設定されたパスを絶対パスへ展開
+	if AppConfig.MemoDir != "" && !filepath.IsAbs(AppConfig.MemoDir) {
+		if abs, err := filepath.Abs(AppConfig.MemoDir); err == nil {
+			AppConfig.MemoDir = abs
+		}
+	}
+	if AppConfig.IndexPath != "" && !filepath.IsAbs(AppConfig.IndexPath) {
+		if abs, err := filepath.Abs(AppConfig.IndexPath); err == nil {
+			AppConfig.IndexPath = abs
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -5,12 +5,16 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"ykvario.com/MemoIndex/config"
 	"ykvario.com/MemoIndex/index"
 	"ykvario.com/MemoIndex/note"
 	"ykvario.com/MemoIndex/search"
 )
 
 func main() {
+	// 設定ファイル読み込み
+	config.LoadConfig("config.yaml")
+
 	var rootCmd = &cobra.Command{
 		Use:   "memoindex",
 		Short: "MemoIndex - メモ検索＆新規作成CLIツール",

--- a/search/search.go
+++ b/search/search.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/spf13/cobra"
-)
 
-var indexPath = "memoindex.bleve"
+	"ykvario.com/MemoIndex/config"
+)
 
 var SearchCmd = &cobra.Command{
 	Use:   "search [query]",
@@ -17,6 +17,11 @@ var SearchCmd = &cobra.Command{
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		queryText := strings.Join(args, " ")
+
+		indexPath := config.AppConfig.IndexPath
+		if indexPath == "" {
+			indexPath = "./memoindex.bleve"
+		}
 
 		index, err := bleve.Open(indexPath)
 		if err != nil {


### PR DESCRIPTION
## Summary
- convert `memo_dir` and `index_path` to absolute paths when loading config
- load configuration in `main.go`
- update search command to respect configured index path
- document that `config.yaml` can use absolute paths

## Testing
- `go test ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_687e36b574d48323a0eaa82621f98076