### PR TITLE
Handle missing config on startup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,22 @@ type Config struct {
 var AppConfig Config
 
 func LoadConfig(path string) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		// 設定ファイルが無ければデフォルト設定で生成
+		defaultCfg := Config{
+			MemoDir:   "./memo",
+			IndexPath: "./memoindex.bleve",
+			Editor:    "notepad",
+		}
+		data, err := yaml.Marshal(&defaultCfg)
+		if err != nil {
+			log.Fatalf("設定ファイル生成失敗: %v", err)
+		}
+		if err := os.WriteFile(path, data, 0644); err != nil {
+			log.Fatalf("設定ファイル生成失敗: %v", err)
+		}
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		log.Fatalf("設定ファイル読み込み失敗: %v", err)


### PR DESCRIPTION
## Summary
- create a default `config.yaml` when it does not exist

## Testing
- `go vet ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e391d13e88323bcf5cfbf98feeddd