### PR TITLE
Add GUI and refactor CLI utilities

### DIFF
--- a/gui/gui.go
+++ b/gui/gui.go
@@ -1,0 +1,68 @@
+package gui
+
+import (
+	"fmt"
+	"log"
+
+	"fyne.io/fyne/v2/app"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
+	"github.com/spf13/cobra"
+
+	"ykvario.com/MemoIndex/note"
+	"ykvario.com/MemoIndex/search"
+)
+
+// GuiCmd defines the CLI command to start the GUI.
+var GuiCmd = &cobra.Command{
+	Use:   "gui",
+	Short: "GUIアプリを起動します",
+	Run: func(cmd *cobra.Command, args []string) {
+		Run()
+	},
+}
+
+// Run launches the Fyne based GUI application.
+func Run() {
+	a := app.New()
+	w := a.NewWindow("MemoIndex")
+
+	entry := widget.NewEntry()
+	entry.SetPlaceHolder("検索ワード")
+
+	resultBox := widget.NewMultiLineLabel("")
+	resultBox.Wrapping = fyne.TextWrapWord
+
+	searchButton := widget.NewButton("検索", func() {
+		results, err := search.ExecuteSearch(entry.Text, 3)
+		if err != nil {
+			log.Println(err)
+			return
+		}
+		if len(results) == 0 {
+			resultBox.SetText("検索結果がありません。")
+			return
+		}
+		text := ""
+		for i, r := range results {
+			text += fmt.Sprintf("%d. %s\n   ...%s...\n", i+1, r.Path, r.Fragment)
+		}
+		resultBox.SetText(text)
+	})
+
+	newButton := widget.NewButton("新規メモ", func() {
+		path, err := note.CreateNewNote("")
+		if err != nil {
+			log.Println(err)
+			resultBox.SetText(fmt.Sprintf("エラー: %v", err))
+			return
+		}
+		resultBox.SetText(fmt.Sprintf("作成: %s", path))
+	})
+
+	control := container.NewHBox(entry, searchButton, newButton)
+	content := container.NewVBox(control, resultBox)
+
+	w.SetContent(content)
+	w.ShowAndRun()
+}

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"ykvario.com/MemoIndex/config"
+	"ykvario.com/MemoIndex/gui"
 	"ykvario.com/MemoIndex/index"
 	"ykvario.com/MemoIndex/note"
 	"ykvario.com/MemoIndex/search"
@@ -23,6 +24,7 @@ func main() {
 	rootCmd.AddCommand(search.SearchCmd)
 	rootCmd.AddCommand(note.NewNoteCmd)
 	rootCmd.AddCommand(index.ReindexCmd)
+	rootCmd.AddCommand(gui.GuiCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/note/new.go
+++ b/note/new.go
@@ -22,49 +22,68 @@ var NewNoteCmd = &cobra.Command{
 		filename := ""
 		if len(args) > 0 {
 			filename = args[0]
-		} else {
-			filename = fmt.Sprintf("memo_%s.txt", time.Now().Format("20060102_150405"))
 		}
 
-		// メモディレクトリ構成
-		memoDirs := config.AppConfig.MemoDirs
-		memoDir := "./memo"
-		if len(memoDirs) > 0 {
-			memoDir = memoDirs[0]
-		}
-		err := os.MkdirAll(memoDir, os.ModePerm)
-		if err != nil {
-			log.Fatalf("メモディレクトリ作成失敗: %v", err)
-		}
-
-		filepathAbs := filepath.Join(memoDir, filename)
-
-		// ファイル作成
-		err = os.WriteFile(filepathAbs, []byte(""), 0644)
-		if err != nil {
-			log.Fatalf("ファイル作成に失敗: %v", err)
-		}
-		fmt.Println("作成:", filepathAbs)
-
-		// エディタ起動
-		editor := config.AppConfig.Editor
-		if editor == "" {
-			editor = os.Getenv("EDITOR")
-		}
-		if editor == "" {
-			editor = "notepad"
-		}
-
-		cmdEditor := exec.Command(editor, filepathAbs)
-		cmdEditor.Stdin = os.Stdin
-		cmdEditor.Stdout = os.Stdout
-		cmdEditor.Stderr = os.Stderr
-		cmdEditor.Run()
-
-		// インデックス登録（外部関数へ委譲）
-		err = index.IndexFile(filepathAbs)
-		if err != nil {
-			log.Fatalf("インデックス登録失敗: %v", err)
+		if _, err := CreateNewNote(filename); err != nil {
+			log.Fatalf("%v", err)
 		}
 	},
+}
+
+// CreateNewNote creates a new memo file, opens it with the configured
+// editor and indexes the file. The created absolute path is returned.
+func CreateNewNote(filename string) (string, error) {
+	if filename == "" {
+		filename = fmt.Sprintf("memo_%s.txt", time.Now().Format("20060102_150405"))
+	}
+
+	memoDirs := config.AppConfig.MemoDirs
+	memoDir := "./memo"
+	if len(memoDirs) > 0 {
+		memoDir = memoDirs[0]
+	}
+	if err := os.MkdirAll(memoDir, os.ModePerm); err != nil {
+		return "", fmt.Errorf("メモディレクトリ作成失敗: %w", err)
+	}
+
+	filepathAbs := filepath.Join(memoDir, filename)
+	if err := os.WriteFile(filepathAbs, []byte(""), 0644); err != nil {
+		return "", fmt.Errorf("ファイル作成に失敗: %w", err)
+	}
+	fmt.Println("作成:", filepathAbs)
+
+	editor := config.AppConfig.Editor
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+	}
+	if editor == "" {
+		editor = "notepad"
+	}
+
+	cmdEditor := exec.Command(editor, filepathAbs)
+	cmdEditor.Stdin = os.Stdin
+	cmdEditor.Stdout = os.Stdout
+	cmdEditor.Stderr = os.Stderr
+	if err := cmdEditor.Run(); err != nil {
+		return "", fmt.Errorf("エディタ起動失敗: %w", err)
+	}
+
+	if err := index.IndexFile(filepathAbs); err != nil {
+		return "", fmt.Errorf("インデックス登録失敗: %w", err)
+	}
+
+	return filepathAbs, nil
+}
+
+// OpenFile opens the specified file with the configured editor.
+func OpenFile(path string) error {
+	editor := config.AppConfig.Editor
+	if editor == "" {
+		editor = os.Getenv("EDITOR")
+	}
+	if editor == "" {
+		editor = "notepad"
+	}
+	cmdEditor := exec.Command(editor, path)
+	return cmdEditor.Start()
 }

--- a/search/search.go
+++ b/search/search.go
@@ -10,6 +10,45 @@ import (
 	"ykvario.com/MemoIndex/config"
 )
 
+// Result represents a single search hit.
+type Result struct {
+	Path     string
+	Fragment string
+}
+
+// ExecuteSearch performs a search against the index and returns up to limit results.
+func ExecuteSearch(queryText string, limit int) ([]Result, error) {
+	indexPath := config.AppConfig.IndexPath
+	if indexPath == "" {
+		indexPath = "./memoindex.bleve"
+	}
+
+	index, err := bleve.Open(indexPath)
+	if err != nil {
+		return nil, fmt.Errorf("インデックスの読み込みに失敗しました: %w", err)
+	}
+	defer index.Close()
+
+	q := bleve.NewMatchQuery(queryText)
+	searchReq := bleve.NewSearchRequestOptions(q, limit, 0, false)
+	searchReq.Highlight = bleve.NewHighlight()
+
+	result, err := index.Search(searchReq)
+	if err != nil {
+		return nil, fmt.Errorf("検索に失敗しました: %w", err)
+	}
+
+	hits := make([]Result, 0, len(result.Hits))
+	for _, hit := range result.Hits {
+		frag := ""
+		if fragments, ok := hit.Fragments["body"]; ok && len(fragments) > 0 {
+			frag = fragments[0]
+		}
+		hits = append(hits, Result{Path: hit.ID, Fragment: frag})
+	}
+	return hits, nil
+}
+
 var SearchCmd = &cobra.Command{
 	Use:   "search [query]",
 	Short: "全文検索を行います（上位3件を表示）",
@@ -17,35 +56,20 @@ var SearchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		queryText := strings.Join(args, " ")
 
-		indexPath := config.AppConfig.IndexPath
-		if indexPath == "" {
-			indexPath = "./memoindex.bleve"
-		}
-
-		index, err := bleve.Open(indexPath)
+		results, err := ExecuteSearch(queryText, 3)
 		if err != nil {
-			log.Fatalf("インデックスの読み込みに失敗しました: %v", err)
-		}
-		defer index.Close()
-
-		q := bleve.NewMatchQuery(queryText)
-		search := bleve.NewSearchRequestOptions(q, 3, 0, false)
-		search.Highlight = bleve.NewHighlight()
-
-		result, err := index.Search(search)
-		if err != nil {
-			log.Fatalf("検索に失敗しました: %v", err)
+			log.Fatalf("%v", err)
 		}
 
-		if result.Total == 0 {
+		if len(results) == 0 {
 			fmt.Println("検索結果がありません。")
 			return
 		}
 
-		for i, hit := range result.Hits {
-			fmt.Printf("%d. %s\n", i+1, hit.ID)
-			if fragments, ok := hit.Fragments["body"]; ok && len(fragments) > 0 {
-				fmt.Printf("   ...%s...\n", fragments[0])
+		for i, hit := range results {
+			fmt.Printf("%d. %s\n", i+1, hit.Path)
+			if hit.Fragment != "" {
+				fmt.Printf("   ...%s...\n", hit.Fragment)
 			}
 		}
 	},


### PR DESCRIPTION
## Summary
- implement a minimal Fyne GUI and expose it via `memoindex gui`
- refactor note creation into callable functions
- expose search functionality for reuse
- register the new GUI command in `main.go`

## Testing
- `go build ./...` *(fails: proxy blocked)*
- `go mod tidy` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687e3ed772548323ba9d0d5c46da8791