### PR TITLE
Add i18n support and CLI config commands

### DIFF
--- a/cfgcmd/cmd.go
+++ b/cfgcmd/cmd.go
@@ -1,0 +1,88 @@
+package cfgcmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"ykvario.com/MemoIndex/config"
+	"ykvario.com/MemoIndex/i18n"
+)
+
+// Cmd is the root command for configuration operations.
+var Cmd = &cobra.Command{
+	Use:   "config",
+	Short: "アプリ設定を変更します",
+}
+
+var langCmd = &cobra.Command{
+	Use:   "lang [locale]",
+	Short: "使用言語を設定します",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		lang := args[0]
+		config.AppConfig.Language = lang
+		if err := config.SaveConfig("config.yaml"); err != nil {
+			return err
+		}
+		if err := i18n.Load(lang); err != nil {
+			return err
+		}
+		fmt.Println(i18n.T("language_set", map[string]interface{}{"Lang": lang}))
+		return nil
+	},
+}
+
+var addDirCmd = &cobra.Command{
+	Use:   "add-dir [path]",
+	Short: "インデックス対象ディレクトリを追加します",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := args[0]
+		for _, d := range config.AppConfig.MemoDirs {
+			if d == dir {
+				fmt.Println(i18n.T("already_exists", map[string]interface{}{"Dir": dir}))
+				return nil
+			}
+		}
+		config.AppConfig.MemoDirs = append(config.AppConfig.MemoDirs, dir)
+		if err := config.SaveConfig("config.yaml"); err != nil {
+			return err
+		}
+		fmt.Println(i18n.T("dir_added", map[string]interface{}{"Dir": dir}))
+		return nil
+	},
+}
+
+var removeDirCmd = &cobra.Command{
+	Use:   "remove-dir [path]",
+	Short: "インデックス対象ディレクトリを削除します",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := args[0]
+		newDirs := []string{}
+		found := false
+		for _, d := range config.AppConfig.MemoDirs {
+			if d == dir {
+				found = true
+				continue
+			}
+			newDirs = append(newDirs, d)
+		}
+		if !found {
+			fmt.Println(i18n.T("dir_not_found", map[string]interface{}{"Dir": dir}))
+			return nil
+		}
+		config.AppConfig.MemoDirs = newDirs
+		if err := config.SaveConfig("config.yaml"); err != nil {
+			return err
+		}
+		fmt.Println(i18n.T("dir_removed", map[string]interface{}{"Dir": dir}))
+		return nil
+	},
+}
+
+func init() {
+	Cmd.AddCommand(langCmd)
+	Cmd.AddCommand(addDirCmd)
+	Cmd.AddCommand(removeDirCmd)
+}

--- a/config.yaml
+++ b/config.yaml
@@ -3,3 +3,4 @@ memo_dirs:
   - "./note"
 index_path: "./memoindex.bleve"
 editor: "notepad"
+language: "ja"

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -3,3 +3,4 @@ memo_dirs:
   - "./note"
 index_path: "./memoindex.bleve"
 editor: "notepad"
+language: "ja"

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"log"
 	"os"
 
@@ -11,6 +12,7 @@ type Config struct {
 	MemoDirs  []string `yaml:"memo_dirs"` // 複数対応に変更
 	IndexPath string   `yaml:"index_path"`
 	Editor    string   `yaml:"editor"`
+	Language  string   `yaml:"language"`
 }
 
 var AppConfig Config
@@ -24,4 +26,15 @@ func LoadConfig(path string) {
 	if err != nil {
 		log.Fatalf("設定パース失敗: %v", err)
 	}
+}
+
+func SaveConfig(path string) error {
+	data, err := yaml.Marshal(&AppConfig)
+	if err != nil {
+		return fmt.Errorf("設定シリアライズ失敗: %w", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("設定ファイル書き込み失敗: %w", err)
+	}
+	return nil
 }

--- a/gui/gui.go
+++ b/gui/gui.go
@@ -9,6 +9,7 @@ import (
 	"fyne.io/fyne/v2/widget"
 	"github.com/spf13/cobra"
 
+	"ykvario.com/MemoIndex/i18n"
 	"ykvario.com/MemoIndex/note"
 	"ykvario.com/MemoIndex/search"
 )
@@ -28,19 +29,19 @@ func Run() {
 	w := a.NewWindow("MemoIndex")
 
 	entry := widget.NewEntry()
-	entry.SetPlaceHolder("検索ワード")
+	entry.SetPlaceHolder(i18n.T("search_placeholder", nil))
 
 	resultBox := widget.NewMultiLineLabel("")
 	resultBox.Wrapping = fyne.TextWrapWord
 
-	searchButton := widget.NewButton("検索", func() {
+	searchButton := widget.NewButton(i18n.T("search", nil), func() {
 		results, err := search.ExecuteSearch(entry.Text, 3)
 		if err != nil {
 			log.Println(err)
 			return
 		}
 		if len(results) == 0 {
-			resultBox.SetText("検索結果がありません。")
+			resultBox.SetText(i18n.T("no_results", nil))
 			return
 		}
 		text := ""
@@ -50,14 +51,14 @@ func Run() {
 		resultBox.SetText(text)
 	})
 
-	newButton := widget.NewButton("新規メモ", func() {
+	newButton := widget.NewButton(i18n.T("new_note", nil), func() {
 		path, err := note.CreateNewNote("")
 		if err != nil {
 			log.Println(err)
-			resultBox.SetText(fmt.Sprintf("エラー: %v", err))
+			resultBox.SetText(i18n.T("error", map[string]interface{}{"Err": err}))
 			return
 		}
-		resultBox.SetText(fmt.Sprintf("作成: %s", path))
+		resultBox.SetText(i18n.T("created", map[string]interface{}{"Path": path}))
 	})
 
 	control := container.NewHBox(entry, searchButton, newButton)

--- a/i18n/active.en.yaml
+++ b/i18n/active.en.yaml
@@ -4,3 +4,21 @@ search:
   other: "Search"
 new_note:
   other: "New Note"
+language_set:
+  other: "Language set to {{.Lang}}"
+dir_added:
+  other: "Added {{.Dir}}"
+dir_removed:
+  other: "Removed {{.Dir}}"
+dir_not_found:
+  other: "{{.Dir}} not found"
+already_exists:
+  other: "{{.Dir}} already exists"
+search_placeholder:
+  other: "Search word"
+no_results:
+  other: "No results found."
+created:
+  other: "Created: {{.Path}}"
+error:
+  other: "Error: {{.Err}}"

--- a/i18n/active.ja.yaml
+++ b/i18n/active.ja.yaml
@@ -4,3 +4,21 @@ search:
   other: "検索"
 new_note:
   other: "新規メモ"
+language_set:
+  other: "言語を{{.Lang}}に設定しました"
+dir_added:
+  other: "{{.Dir}} を追加しました"
+dir_removed:
+  other: "{{.Dir}} を削除しました"
+dir_not_found:
+  other: "{{.Dir}} が見つかりません"
+already_exists:
+  other: "{{.Dir}} は既に存在します"
+search_placeholder:
+  other: "検索ワード"
+no_results:
+  other: "検索結果がありません。"
+created:
+  other: "作成: {{.Path}}"
+error:
+  other: "エラー: {{.Err}}"

--- a/i18n/i18n.go
+++ b/i18n/i18n.go
@@ -1,0 +1,45 @@
+package i18n
+
+import (
+	"embed"
+
+	"github.com/nicksnyder/go-i18n/v2/i18n"
+	"golang.org/x/text/language"
+	"gopkg.in/yaml.v3"
+)
+
+var bundle *i18n.Bundle
+var localizer *i18n.Localizer
+
+//go:embed *.yaml
+var localeFS embed.FS
+
+// Load initializes the localization bundle and sets the active language.
+func Load(lang string) error {
+	bundle = i18n.NewBundle(language.English)
+	bundle.RegisterUnmarshalFunc("yaml", yaml.Unmarshal)
+
+	entries, err := localeFS.ReadDir(".")
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if _, err := bundle.LoadMessageFileFS(localeFS, e.Name()); err != nil {
+			return err
+		}
+	}
+	localizer = i18n.NewLocalizer(bundle, lang)
+	return nil
+}
+
+// T localizes the given message ID using optional template data.
+func T(id string, data map[string]interface{}) string {
+	if localizer == nil {
+		return id
+	}
+	msg, err := localizer.Localize(&i18n.LocalizeConfig{MessageID: id, TemplateData: data})
+	if err != nil {
+		return id
+	}
+	return msg
+}

--- a/main.go
+++ b/main.go
@@ -5,8 +5,10 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"ykvario.com/MemoIndex/cfgcmd"
 	"ykvario.com/MemoIndex/config"
 	"ykvario.com/MemoIndex/gui"
+	"ykvario.com/MemoIndex/i18n"
 	"ykvario.com/MemoIndex/index"
 	"ykvario.com/MemoIndex/note"
 	"ykvario.com/MemoIndex/search"
@@ -15,6 +17,10 @@ import (
 func main() {
 	// 設定ファイル読み込み
 	config.LoadConfig("config.yaml")
+	// i18n ロード
+	if err := i18n.Load(config.AppConfig.Language); err != nil {
+		fmt.Println(err)
+	}
 
 	var rootCmd = &cobra.Command{
 		Use:   "memoindex",
@@ -25,6 +31,7 @@ func main() {
 	rootCmd.AddCommand(note.NewNoteCmd)
 	rootCmd.AddCommand(index.ReindexCmd)
 	rootCmd.AddCommand(gui.GuiCmd)
+	rootCmd.AddCommand(cfgcmd.Cmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/note/new.go
+++ b/note/new.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"ykvario.com/MemoIndex/config"
+	"ykvario.com/MemoIndex/i18n"
 	"ykvario.com/MemoIndex/index"
 )
 
@@ -50,7 +51,7 @@ func CreateNewNote(filename string) (string, error) {
 	if err := os.WriteFile(filepathAbs, []byte(""), 0644); err != nil {
 		return "", fmt.Errorf("ファイル作成に失敗: %w", err)
 	}
-	fmt.Println("作成:", filepathAbs)
+	fmt.Println(i18n.T("created", map[string]interface{}{"Path": filepathAbs}))
 
 	editor := config.AppConfig.Editor
 	if editor == "" {

--- a/search/search.go
+++ b/search/search.go
@@ -8,6 +8,7 @@ import (
 	"github.com/blevesearch/bleve/v2"
 	"github.com/spf13/cobra"
 	"ykvario.com/MemoIndex/config"
+	"ykvario.com/MemoIndex/i18n"
 )
 
 // Result represents a single search hit.
@@ -62,7 +63,7 @@ var SearchCmd = &cobra.Command{
 		}
 
 		if len(results) == 0 {
-			fmt.Println("検索結果がありません。")
+			fmt.Println(i18n.T("no_results", nil))
 			return
 		}
 


### PR DESCRIPTION
## Summary
- implement i18n loader and translation helper
- support language and memo directory settings via `memoindex config`
- wire i18n into GUI and CLI messages
- add language field in configuration and sample files

## Testing
- `go mod tidy` *(fails: proxy.golang.org forbidden)*
- `go build ./...` *(fails: proxy.golang.org forbidden)*
- `go test ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687e421da6788323bba624e8124fa2fb