### PR TITLE
Add Reindex button to GUI

### DIFF
--- a/i18n/active.en.yaml
+++ b/i18n/active.en.yaml
@@ -22,3 +22,7 @@ created:
   other: "Created: {{.Path}}"
 error:
   other: "Error: {{.Err}}"
+reindex:
+  other: "Reindex"
+reindex_done:
+  other: "Reindex completed: {{.Count}} entries indexed"

--- a/i18n/active.ja.yaml
+++ b/i18n/active.ja.yaml
@@ -22,3 +22,7 @@ created:
   other: "作成: {{.Path}}"
 error:
   other: "エラー: {{.Err}}"
+reindex:
+  other: "再インデックス"
+reindex_done:
+  other: "再インデックス完了: {{.Count}} 件登録"

--- a/index/reindex.go
+++ b/index/reindex.go
@@ -17,42 +17,52 @@ var ReindexCmd = &cobra.Command{
 	Use:   "reindex",
 	Short: "メモフォルダ内のすべてのファイルを再インデックス化します",
 	Run: func(cmd *cobra.Command, args []string) {
-		memoDirs := config.AppConfig.MemoDirs
-		if len(memoDirs) == 0 {
-			memoDirs = []string{"./memo"} // デフォルト
+		count, err := ReindexAll()
+		if err != nil {
+			log.Printf("再インデックス中にエラー: %v", err)
 		}
-
-		count := 0
-		for _, memoDir := range memoDirs {
-			if _, err := os.Stat(memoDir); os.IsNotExist(err) {
-				log.Printf("スキップ: メモフォルダが存在しません: %s", memoDir)
-				continue
-			}
-
-			err := filepath.WalkDir(memoDir, func(path string, d fs.DirEntry, err error) error {
-				if err != nil {
-					return err
-				}
-				if d.IsDir() {
-					return nil
-				}
-				ext := strings.ToLower(filepath.Ext(path))
-				if ext != ".txt" && ext != ".md" && ext != ".html" {
-					return nil
-				}
-
-				if err := IndexFile(path); err != nil {
-					log.Printf("インデックス登録失敗: %v", err)
-				} else {
-					count++
-				}
-				return nil
-			})
-			if err != nil {
-				log.Printf("再インデックス中にエラー: %v", err)
-			}
-		}
-
 		fmt.Printf("再インデックス完了: %d 件登録\n", count)
 	},
+}
+
+// ReindexAll reindexes all files under configured memo directories.
+// The number of indexed files is returned.
+func ReindexAll() (int, error) {
+	memoDirs := config.AppConfig.MemoDirs
+	if len(memoDirs) == 0 {
+		memoDirs = []string{"./memo"} // デフォルト
+	}
+
+	count := 0
+	for _, memoDir := range memoDirs {
+		if _, err := os.Stat(memoDir); os.IsNotExist(err) {
+			log.Printf("スキップ: メモフォルダが存在しません: %s", memoDir)
+			continue
+		}
+
+		err := filepath.WalkDir(memoDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				return nil
+			}
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext != ".txt" && ext != ".md" && ext != ".html" {
+				return nil
+			}
+
+			if err := IndexFile(path); err != nil {
+				log.Printf("インデックス登録失敗: %v", err)
+			} else {
+				count++
+			}
+			return nil
+		})
+		if err != nil {
+			return count, err
+		}
+	}
+
+	return count, nil
 }


### PR DESCRIPTION
## Summary
- enable dynamic button layout to support multiple buttons
- add `ReindexAll` helper and wire CLI command to use it
- expose a "Reindex" button in the GUI
- add translation strings for the new button

## Testing
- `go vet ./...` *(fails: Forbidden access to proxy)*
- `go test ./...` *(fails: Forbidden access to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_687f19a2f8108323a38278e7a7c5be40