### PR TITLE
Add user guide README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,189 +1,45 @@
 # MemoIndex
 
-指定フォルダ内の `.txt`, `.md`, `.html` ファイルを自動インデックス化し、全文検索・新規作成を可能にするローカルアプリです。  
-CLI（コマンドライン）とGUI（専用ウィンドウ）の両方から利用できます。
+MemoIndex は、指定したフォルダ内のテキストファイルを自動でインデックス化し、素早く全文検索できるローカルアプリです。GUI ウィンドウまたは CLI から利用できます。
 
----
+## 特長
 
-## 機能概要
+- `.txt` / `.md` / `.html` の内容を自動でインデックス化
+- ファイルを追加・編集するとインデックスを自動更新
+- 高速全文検索とスニペット表示
+- ワンクリックで新規メモ帳を作成
 
-- 指定フォルダ配下の `.txt`, `.md`, `.html` ファイルのみ自動インデックス化
-- ファイルの追加・変更・削除をリアルタイムで監視し、インデックスを自動更新
-- 高速全文検索とヒット箇所のスニペット（前後30文字）表示
-- 新規メモ帳作成（エディタ自動起動＆即インデックス化）
-- CLI／GUI（専用ウィンドウ）両対応
+## インストール
 
----
-
-## 画面イメージ
-
-### 専用ウィンドウ（GUI）
-
-- 検索ボックス＋検索ボタン
-- 新規メモ帳ボタン
-- 検索結果一覧（ファイル名＋スニペット、クリックでファイルを開く／検索結果は閉じない）
-
-```
-
----
-
-## | 🔍 \[検索ワード                 ]\[検索]   \[＋新規メモ]
-
-\| 検索結果:
-\|  - notes/bleve\_tips.txt
-\|     ...Goで全文検索をするならBleve。基本的な使い方としては...
-\|  - docs/search\_engine.md
-\|     ...全文検索（Full-text search）は、Go言語のBleveが...
-\|  - web/index.html
-\|     ...<h2>Go言語による全文検索の実装例</h2>...
--------------------------------------
-
-````
-
-### CLI
-
-#### ファイル検索（上位3件＋スニペット表示）
-
-```bash
-memoindex search "検索ワード"
-````
-
-出力例:
-
-```
-1. notes/bleve_tips.txt
-   ...Goで全文検索をするならBleve。基本的な使い方としては...
-
-2. docs/search_engine.md
-   ...全文検索（Full-text search）は、Go言語のBleveが...
-
-3. web/index.html
-   ...<h2>Go言語による全文検索の実装例</h2>...
-```
-
-#### 新規メモ帳作成
-
-```bash
-memoindex new [ファイル名]
-```
-
-指定したファイル名（省略時は日時など自動付与）で新規メモ帳を作成し、既定のエディタで開きます。
-
----
-
-## システム仕様
-
-* **インデックス対象**:
-
-  * 指定ディレクトリ以下の `.txt`, `.md`, `.html` ファイルのみ
-* **自動監視・更新**:
-
-  * フォルダを監視し、ファイルの追加・編集・削除に応じて自動でBleveインデックスを更新
-* **検索機能**:
-
-  * 全文検索（AND/OR/部分一致）
-  * ヒットしたファイルのパス＋該当箇所のスニペット（前後30文字）表示
-* **新規メモ帳**:
-
-  * ワンクリックまたはコマンド一発で空ファイル作成＋既定エディタ自動起動＋自動インデックス登録
-* **複数窓同時起動可**（CLI・GUI混在可）
-* **設定ファイル**:
-
-  * 監視フォルダやエディタパス、除外ディレクトリなどを設定可能
-
----
-
-## 技術構成
-
-* **言語**: Go
-* **全文検索エンジン**: [Bleve](https://github.com/blevesearch/bleve)
-* **ファイル監視**: [fsnotify](https://github.com/fsnotify/fsnotify)
-* **GUI**: fyne, go-astilectron等
-* **CLI**: Cobra, urfave/cli等
-
----
+1. Go をインストールします。
+2. このリポジトリをクローン後、 `go build -o memoindex` でバイナリを作成します。ビルドせずに `go run .` で実行することも可能です。
+3. `config.yaml.sample` を `config.yaml` にコピーし、監視したいフォルダやエディタパスを設定します。
 
 ## 使い方
 
-### 1. インストール・初期設定
-
-1. Goインストール
-2. 本リポジトリをクローン
-3. `go build -o memoindex` で実行ファイルを作成（`go run .` でも試せます）
-   - 生成された `memoindex` バイナリひとつで CLI と GUI の両方を起動できます
-4. `config.yaml.sample` を `config.yaml` にコピーして監視フォルダ等を設定
-   - `memo_dirs` や `index_path` には絶対パスも指定可能です
-
-### 2. 起動
-
-* CLI:
-
-  ```bash
-  memoindex search "Go全文検索"
-  memoindex new mymemo.txt
-  memoindex reindex
-  
-  # ビルドせずに試す場合
-  go run . search "Go全文検索"
-  ```
-* GUI:
-
-  ```bash
-  ./memoindex gui     # GUI ウィンドウを起動
-  
-  # ビルドせずに試す場合
-  go run . gui
-  ```
-
-### 3. ビルドとリリース
-
-#### クロスコンパイル
-
-CLI 用バイナリは `GOOS` と `GOARCH` を指定してビルドできます。
+### CLI
 
 ```bash
-# Windows 64bit 向け
-GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o memoindex.exe
-
-# Linux 64bit 向け
-GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o memoindex
+./memoindex search "キーワード"   # 検索
+./memoindex new [ファイル名]       # 新規メモ作成
+./memoindex gui                    # GUI を起動
 ```
 
-GUI を含めたバイナリを生成する場合は [fyne](https://github.com/fyne-io/fyne) の
-ツールを利用します。
+### GUI
 
-```bash
-# fyne ツールをインストール
-go install fyne.io/fyne/v2/cmd/fyne@latest
+`./memoindex gui` を実行すると検索ボックス付きのウィンドウが開きます。検索や新規メモ作成をボタン操作で行えます。
 
-# Windows 用 GUI ビルド
-fyne package -os windows -release
+## 設定
 
-# Linux 用 GUI ビルド
-fyne package -os linux -release
-```
+`config.yaml` で以下を設定できます。
 
-#### 配布例
-
-生成したバイナリと `config.yaml.sample` を zip 等にまとめて GitHub Releases へアップロードします。  
-CI (`.github/workflows/go.yml`) を拡張すれば、タグ作成時に自動ビルド・アーカイブ生成も可能です。
-
----
+- `memo_dirs` : 監視するフォルダのパス (複数指定可)
+- `index_path` : インデックスファイルの保存先
+- `editor` : 新規メモ作成時に開くエディタ
+- `language` : 使用する言語 (検索結果表示など)
 
 ## ライセンス
 
 MIT
 
----
-
-## TODO / 今後の予定
-
-* 検索結果のフィルタ・ソート
-* 高度な検索構文（正規表現・タグ付け等）
-* インデックス対象の拡張（PDF等）
-
----
-
-## 開発・コントリビュート
-
-PR・Issue歓迎です！
+開発に関する詳細な情報は `development_Readme.md` を参照してください。

--- a/development_Readme.md
+++ b/development_Readme.md
@@ -1,0 +1,189 @@
+# MemoIndex
+
+指定フォルダ内の `.txt`, `.md`, `.html` ファイルを自動インデックス化し、全文検索・新規作成を可能にするローカルアプリです。  
+CLI（コマンドライン）とGUI（専用ウィンドウ）の両方から利用できます。
+
+---
+
+## 機能概要
+
+- 指定フォルダ配下の `.txt`, `.md`, `.html` ファイルのみ自動インデックス化
+- ファイルの追加・変更・削除をリアルタイムで監視し、インデックスを自動更新
+- 高速全文検索とヒット箇所のスニペット（前後30文字）表示
+- 新規メモ帳作成（エディタ自動起動＆即インデックス化）
+- CLI／GUI（専用ウィンドウ）両対応
+
+---
+
+## 画面イメージ
+
+### 専用ウィンドウ（GUI）
+
+- 検索ボックス＋検索ボタン
+- 新規メモ帳ボタン
+- 検索結果一覧（ファイル名＋スニペット、クリックでファイルを開く／検索結果は閉じない）
+
+```
+
+---
+
+## | 🔍 \[検索ワード                 ]\[検索]   \[＋新規メモ]
+
+\| 検索結果:
+\|  - notes/bleve\_tips.txt
+\|     ...Goで全文検索をするならBleve。基本的な使い方としては...
+\|  - docs/search\_engine.md
+\|     ...全文検索（Full-text search）は、Go言語のBleveが...
+\|  - web/index.html
+\|     ...<h2>Go言語による全文検索の実装例</h2>...
+-------------------------------------
+
+````
+
+### CLI
+
+#### ファイル検索（上位3件＋スニペット表示）
+
+```bash
+memoindex search "検索ワード"
+````
+
+出力例:
+
+```
+1. notes/bleve_tips.txt
+   ...Goで全文検索をするならBleve。基本的な使い方としては...
+
+2. docs/search_engine.md
+   ...全文検索（Full-text search）は、Go言語のBleveが...
+
+3. web/index.html
+   ...<h2>Go言語による全文検索の実装例</h2>...
+```
+
+#### 新規メモ帳作成
+
+```bash
+memoindex new [ファイル名]
+```
+
+指定したファイル名（省略時は日時など自動付与）で新規メモ帳を作成し、既定のエディタで開きます。
+
+---
+
+## システム仕様
+
+* **インデックス対象**:
+
+  * 指定ディレクトリ以下の `.txt`, `.md`, `.html` ファイルのみ
+* **自動監視・更新**:
+
+  * フォルダを監視し、ファイルの追加・編集・削除に応じて自動でBleveインデックスを更新
+* **検索機能**:
+
+  * 全文検索（AND/OR/部分一致）
+  * ヒットしたファイルのパス＋該当箇所のスニペット（前後30文字）表示
+* **新規メモ帳**:
+
+  * ワンクリックまたはコマンド一発で空ファイル作成＋既定エディタ自動起動＋自動インデックス登録
+* **複数窓同時起動可**（CLI・GUI混在可）
+* **設定ファイル**:
+
+  * 監視フォルダやエディタパス、除外ディレクトリなどを設定可能
+
+---
+
+## 技術構成
+
+* **言語**: Go
+* **全文検索エンジン**: [Bleve](https://github.com/blevesearch/bleve)
+* **ファイル監視**: [fsnotify](https://github.com/fsnotify/fsnotify)
+* **GUI**: fyne, go-astilectron等
+* **CLI**: Cobra, urfave/cli等
+
+---
+
+## 使い方
+
+### 1. インストール・初期設定
+
+1. Goインストール
+2. 本リポジトリをクローン
+3. `go build -o memoindex` で実行ファイルを作成（`go run .` でも試せます）
+   - 生成された `memoindex` バイナリひとつで CLI と GUI の両方を起動できます
+4. `config.yaml.sample` を `config.yaml` にコピーして監視フォルダ等を設定
+   - `memo_dirs` や `index_path` には絶対パスも指定可能です
+
+### 2. 起動
+
+* CLI:
+
+  ```bash
+  memoindex search "Go全文検索"
+  memoindex new mymemo.txt
+  memoindex reindex
+  
+  # ビルドせずに試す場合
+  go run . search "Go全文検索"
+  ```
+* GUI:
+
+  ```bash
+  ./memoindex gui     # GUI ウィンドウを起動
+  
+  # ビルドせずに試す場合
+  go run . gui
+  ```
+
+### 3. ビルドとリリース
+
+#### クロスコンパイル
+
+CLI 用バイナリは `GOOS` と `GOARCH` を指定してビルドできます。
+
+```bash
+# Windows 64bit 向け
+GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o memoindex.exe
+
+# Linux 64bit 向け
+GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o memoindex
+```
+
+GUI を含めたバイナリを生成する場合は [fyne](https://github.com/fyne-io/fyne) の
+ツールを利用します。
+
+```bash
+# fyne ツールをインストール
+go install fyne.io/fyne/v2/cmd/fyne@latest
+
+# Windows 用 GUI ビルド
+fyne package -os windows -release
+
+# Linux 用 GUI ビルド
+fyne package -os linux -release
+```
+
+#### 配布例
+
+生成したバイナリと `config.yaml.sample` を zip 等にまとめて GitHub Releases へアップロードします。  
+CI (`.github/workflows/go.yml`) を拡張すれば、タグ作成時に自動ビルド・アーカイブ生成も可能です。
+
+---
+
+## ライセンス
+
+MIT
+
+---
+
+## TODO / 今後の予定
+
+* 検索結果のフィルタ・ソート
+* 高度な検索構文（正規表現・タグ付け等）
+* インデックス対象の拡張（PDF等）
+
+---
+
+## 開発・コントリビュート
+
+PR・Issue歓迎です！


### PR DESCRIPTION
## Summary
- rename the existing developer-focused `Readme.md` to `development_Readme.md`
- create a new `Readme.md` that describes how to install and use MemoIndex

## Testing
- `go test ./...` *(fails: fetching modules forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f1aee71248323a8ab06d99a39c21a