### PR TITLE
Add CLI configuration commands

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -23,6 +23,16 @@ MemoIndex は、指定したフォルダ内のテキストファイルを自動�
 ./memoindex search "キーワード"   # 検索
 ./memoindex new [ファイル名]       # 新規メモ作成
 ./memoindex gui                    # GUI を起動
+./memoindex reindex               # インデックスを再構築
+```
+
+設定変更は `memoindex config` サブコマンドで行えます。例:
+
+```bash
+./memoindex config lang ja            # 言語を日本語に設定
+./memoindex config add-dir ./notes    # フォルダを追加
+./memoindex config index-path ./idx.bleve  # インデックスの保存先変更
+./memoindex config editor vim         # 使用エディター変更
 ```
 
 ### GUI

--- a/cfgcmd/cmd.go
+++ b/cfgcmd/cmd.go
@@ -81,8 +81,40 @@ var removeDirCmd = &cobra.Command{
 	},
 }
 
+var indexPathCmd = &cobra.Command{
+	Use:   "index-path [path]",
+	Short: "インデックスファイルの保存先を設定します",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path := args[0]
+		config.AppConfig.IndexPath = path
+		if err := config.SaveConfig("config.yaml"); err != nil {
+			return err
+		}
+		fmt.Println(i18n.T("index_set", map[string]interface{}{"Path": path}))
+		return nil
+	},
+}
+
+var editorCmd = &cobra.Command{
+	Use:   "editor [command]",
+	Short: "新規メモ作成に使用するエディターを設定します",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ed := args[0]
+		config.AppConfig.Editor = ed
+		if err := config.SaveConfig("config.yaml"); err != nil {
+			return err
+		}
+		fmt.Println(i18n.T("editor_set", map[string]interface{}{"Editor": ed}))
+		return nil
+	},
+}
+
 func init() {
 	Cmd.AddCommand(langCmd)
 	Cmd.AddCommand(addDirCmd)
 	Cmd.AddCommand(removeDirCmd)
+	Cmd.AddCommand(indexPathCmd)
+	Cmd.AddCommand(editorCmd)
 }

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,18 @@
+# メモを保存するフォルダをリストで指定します
+# 例:
+#   - "./memo"
+#   - "/path/to/notes"
 memo_dirs:
   - "./memo"
   - "./note"
+
+# インデックスファイルの保存先
+# 例: "./memoindex.bleve"
 index_path: "./memoindex.bleve"
+
+# 新規メモ作成時に起動するエディター
+# 例: "notepad", "code", "vim"
 editor: "notepad"
+
+# UIメッセージの言語 ("ja" または "en")
 language: "ja"

--- a/config.yaml.sample
+++ b/config.yaml.sample
@@ -1,6 +1,18 @@
+# メモを保存するフォルダをリストで指定します
+# 例:
+#   - "./memo"
+#   - "/path/to/notes"
 memo_dirs:
   - "./memo"
   - "./note"
+
+# インデックスファイルの保存先
+# 例: "./memoindex.bleve"
 index_path: "./memoindex.bleve"
+
+# 新規メモ作成時に起動するエディター
+# 例: "notepad", "code", "vim"
 editor: "notepad"
+
+# UIメッセージの言語 ("ja" または "en")
 language: "ja"

--- a/i18n/active.en.yaml
+++ b/i18n/active.en.yaml
@@ -26,3 +26,7 @@ reindex:
   other: "Reindex"
 reindex_done:
   other: "Reindex completed: {{.Count}} entries indexed"
+index_set:
+  other: "Index file set to {{.Path}}"
+editor_set:
+  other: "Editor set to {{.Editor}}"

--- a/i18n/active.ja.yaml
+++ b/i18n/active.ja.yaml
@@ -26,3 +26,7 @@ reindex:
   other: "再インデックス"
 reindex_done:
   other: "再インデックス完了: {{.Count}} 件登録"
+index_set:
+  other: "インデックスファイルを{{.Path}}に設定しました"
+editor_set:
+  other: "エディターを{{.Editor}}に設定しました"


### PR DESCRIPTION
## Summary
- update CLI usage docs to mention `reindex` and show config examples
- allow setting index path and editor via `memoindex config`
- add i18n messages for new config commands
- document config options in `config.yaml` and sample file

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687f295869a48323ae874b38a1e56950