### PR TITLE
Improve config directory handling

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,7 +30,7 @@ MemoIndex は、指定したフォルダ内のテキストファイルを自動�
 
 ```bash
 ./memoindex config lang ja            # 言語を日本語に設定
-./memoindex config add-dir ./notes    # フォルダを追加
+./memoindex config add-dir ./notes    # フォルダを追加（自動で絶対パスに変換）
 ./memoindex config index-path ./idx.bleve  # インデックスの保存先変更
 ./memoindex config editor vim         # 使用エディター変更
 ```
@@ -47,6 +47,19 @@ MemoIndex は、指定したフォルダ内のテキストファイルを自動�
 - `index_path` : インデックスファイルの保存先
 - `editor` : 新規メモ作成時に開くエディタ
 - `language` : 使用する言語 (検索結果表示など)
+
+### 対応言語
+
+- 日本語 (`ja`)
+- 英語 (`en`)
+
+### 代表的なエディター
+
+- notepad
+- vim
+- nano
+- gedit
+- code (Visual Studio Code)
 
 ## ライセンス
 

--- a/cfgcmd/cmd.go
+++ b/cfgcmd/cmd.go
@@ -2,6 +2,7 @@ package cfgcmd
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"ykvario.com/MemoIndex/config"
@@ -38,17 +39,23 @@ var addDirCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dir := args[0]
+		abs, err := filepath.Abs(dir)
+		if err != nil {
+			return err
+		}
+		abs = filepath.Clean(abs)
+
 		for _, d := range config.AppConfig.MemoDirs {
-			if d == dir {
-				fmt.Println(i18n.T("already_exists", map[string]interface{}{"Dir": dir}))
+			if filepath.Clean(d) == abs {
+				fmt.Println(i18n.T("already_exists", map[string]interface{}{"Dir": abs}))
 				return nil
 			}
 		}
-		config.AppConfig.MemoDirs = append(config.AppConfig.MemoDirs, dir)
+		config.AppConfig.MemoDirs = append(config.AppConfig.MemoDirs, abs)
 		if err := config.SaveConfig("config.yaml"); err != nil {
 			return err
 		}
-		fmt.Println(i18n.T("dir_added", map[string]interface{}{"Dir": dir}))
+		fmt.Println(i18n.T("dir_added", map[string]interface{}{"Dir": abs}))
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary
- store configured directories as absolute paths for robustness
- document supported languages and typical editors
- mention that `add-dir` converts to absolute path automatically

## Testing
- `go test ./...` *(fails: Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687f3514a3688323a3ec311f2aa1a88c